### PR TITLE
removing events from pin

### DIFF
--- a/client/css/force-graph.css
+++ b/client/css/force-graph.css
@@ -54,6 +54,7 @@ g.node circle.disc {
 
 g.node circle.pin {
     fill: transparent;
+    pointer-events: none;
 }
 
 g.node text.name {

--- a/client/js/d3/force-graph.js
+++ b/client/js/d3/force-graph.js
@@ -274,11 +274,7 @@ ForceGraph.prototype.updateNodesAndLinks = function (nodes, links) {
     enterNode
         .append('svg:circle')
             .attr('r', 3)
-            .attr('class', 'pin')
-            .on('mouseover', self.nodeMouseover)
-            .on('mouseout', self.nodeMouseout)
-            .on('click', self.nodeClick)
-            .call(self.drag);
+            .attr('class', 'pin');
     // label
     enterNode
         .append('svg:text')


### PR DESCRIPTION
was creating weird mouseover/mouseout conflicts, which caused me to realize the events were fundamentally unecessary (can just css pointer events none, pass through to main node circle)